### PR TITLE
Validate project name and differentiate policy roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # ShipIt
 
-Easily deploy your machine learning models to an API in the cloud.
+Easily deploy machine learning models to an API in the cloud.
+
+## Prerequisites
+
+Currently AWS is the only provider. You will need an AWS account and credentials that let you modify infrastructure.
 
 ## Quickstart
 
-1. Install and configure awscli
-1. Install terraform
+1. Install and configure docker, awscli, and terraform
 1. `pip install shipit`
 1. `shipit init`
 1. Edit the newly created `shipit.yml` See [configuration](#configuration)
@@ -20,7 +23,7 @@ Version             : 2
 ```
 
 ## How it Works
-Shipit wraps tools like docker, awscli, and terraform to make it easy to deploy production ready web APIs for your machine learning models. First a docker image is built based on the configurat
+Shipit takes a serialized machine learning model (currently sklearn and keras supported) and wraps it in a web api. We build a Docker image from it and then deploy it to a provider like AWS using terraform.
 
 
 ## Running Locally
@@ -126,5 +129,7 @@ Models from `scikit-learn` should be saved with `joblib`. Models from `keras` sh
 - Deploy to Private VPN
 - Route53 / private / public DNS
 - Build an "export" feature for customization of Docker / terraform setup.
+- AWS Lambda Provider
+- Heroku Provider
 - Support XGBoost models
 - Figure out why sklearn.linear_model.LinearRegression can't be pickled

--- a/example/modules/ecs/main.tf
+++ b/example/modules/ecs/main.tf
@@ -142,7 +142,7 @@ data "aws_iam_policy_document" "ecs_service_role" {
 }
 
 resource "aws_iam_role" "ecs_role" {
-  name               = "ecs_role"
+  name               = "${vars.project_name}_ecs_role"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_role.json}"
 }
 
@@ -162,18 +162,18 @@ data "aws_iam_policy_document" "ecs_service_policy" {
 
 /* ecs service scheduler role */
 resource "aws_iam_role_policy" "ecs_service_role_policy" {
-  name   = "ecs_service_role_policy"
+  name   = "${var.project_name}_ecs_service_role_policy"
   policy = "${data.aws_iam_policy_document.ecs_service_policy.json}"
   role   = "${aws_iam_role.ecs_role.id}"
 }
 
 /* role that the Amazon ECS container agent and the Docker daemon can assume */
 resource "aws_iam_role" "ecs_execution_role" {
-  name               = "ecs_task_execution_role"
+  name               = "${var.project_name}_ecs_task_execution_role"
   assume_role_policy = "${file("${path.module}/policies/ecs-task-execution-role.json")}"
 }
 resource "aws_iam_role_policy" "ecs_execution_role_policy" {
-  name   = "ecs_execution_role_policy"
+  name   = "${var.project_name}_ecs_execution_role_policy"
   policy = "${file("${path.module}/policies/ecs-execution-role-policy.json")}"
   role   = "${aws_iam_role.ecs_execution_role.id}"
 }

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,25 @@
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-from os import path
+import os
 from io import open
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+
+def package_files(directory):
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+terraform_files = package_files('shipit/terraform')
+print(terraform_files)
 
 
 setup(
@@ -29,7 +40,7 @@ setup(
     ],
     keywords='machine learning scikit keras docker',
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'example']),  # Required
-    package_data={'': ['shipit.yml', 'Dockerfile', 'config/*']},
+    package_data={'': ['shipit.yml', 'Dockerfile', 'config/*', *terraform_files]},
     include_package_data=True,
     python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     install_requires=[

--- a/shipit/app.py
+++ b/shipit/app.py
@@ -4,6 +4,9 @@ import yaml
 import os
 import numpy as np
 from utils import import_func
+import logging
+
+logger = logging.getLogger('shipit')
 
 
 class ShipIt:
@@ -74,7 +77,9 @@ class ShipIt:
             incoming = preprocess(incoming)
 
         # Generate a prediction
-        prediction = model.predict(incoming)
+        predict_method = model_settings.get('predict_method', 'predict')
+        predict_method = getattr(model, predict_method)
+        prediction = predict_method(incoming)
         prediction = np.atleast_2d(prediction).reshape(len(incoming), -1)
         prediction = prediction.tolist()
 
@@ -124,6 +129,7 @@ def predict(model_name):
         data = {
             "error": str(e)
         }
+        logger.exception(e)
         return Response(json.dumps(data), status=500, mimetype="application/json")
 
 

--- a/shipit/commands.py
+++ b/shipit/commands.py
@@ -162,6 +162,7 @@ def deploy(tag="shipit", verbosity=1):
     init_cmd = delegator.run("terraform init -input=false -from-module={}".format(
         plan_path
     ))
+    print(init_cmd)
     if verbosity > 1:
         logger.info(init_cmd.out)
         logger.info(init_cmd.err)
@@ -175,6 +176,7 @@ def deploy(tag="shipit", verbosity=1):
             plan_path=plan_path,
             vars=get_var_string(vars)
         )
+        print(apply_cmd)
         output = delegator.run(apply_cmd)
         if verbosity > 1:
             logger.info(output.out)

--- a/shipit/terraform/modules/ecs/main.tf
+++ b/shipit/terraform/modules/ecs/main.tf
@@ -142,7 +142,7 @@ data "aws_iam_policy_document" "ecs_service_role" {
 }
 
 resource "aws_iam_role" "ecs_role" {
-  name               = "ecs_role"
+  name               = "${vars.project_name}_ecs_role"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_role.json}"
 }
 
@@ -162,18 +162,18 @@ data "aws_iam_policy_document" "ecs_service_policy" {
 
 /* ecs service scheduler role */
 resource "aws_iam_role_policy" "ecs_service_role_policy" {
-  name   = "ecs_service_role_policy"
+  name   = "${var.project_name}_ecs_service_role_policy"
   policy = "${data.aws_iam_policy_document.ecs_service_policy.json}"
   role   = "${aws_iam_role.ecs_role.id}"
 }
 
 /* role that the Amazon ECS container agent and the Docker daemon can assume */
 resource "aws_iam_role" "ecs_execution_role" {
-  name               = "ecs_task_execution_role"
+  name               = "${var.project_name}_ecs_task_execution_role"
   assume_role_policy = "${file("${path.module}/policies/ecs-task-execution-role.json")}"
 }
 resource "aws_iam_role_policy" "ecs_execution_role_policy" {
-  name   = "ecs_execution_role_policy"
+  name   = "${var.project_name}_ecs_execution_role_policy"
   policy = "${file("${path.module}/policies/ecs-execution-role-policy.json")}"
   role   = "${aws_iam_role.ecs_execution_role.id}"
 }

--- a/shipit/terraform/modules/ecs/main.tf
+++ b/shipit/terraform/modules/ecs/main.tf
@@ -142,7 +142,7 @@ data "aws_iam_policy_document" "ecs_service_role" {
 }
 
 resource "aws_iam_role" "ecs_role" {
-  name               = "${vars.project_name}_ecs_role"
+  name               = "${var.project_name}_ecs_role"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_role.json}"
 }
 

--- a/shipit/utils.py
+++ b/shipit/utils.py
@@ -8,6 +8,15 @@ def load_config():
     return config_data
 
 
+def validate_config(config):
+    """
+    Validate the properties of a configuration file
+    """
+    project_name = config.get("meta", {}).get("project_name", "shipit"),
+    if "_" in project_name:
+        raise Exception("Project name cannot include '_'")
+
+
 def import_func(dot_path):
     """
     Returns a class object from dot path notation


### PR DESCRIPTION
Couple small updates:

* Was getting silent failure on project name with underscore, added validation step
* namespaces policy roles so that if you have multiple shipit projects they don't conflict when you destroy
* small readme updates